### PR TITLE
Fix: allow org and team admin to update all leaves

### DIFF
--- a/src/main/java/app/teamwize/api/leave/repository/LeaveRepository.java
+++ b/src/main/java/app/teamwize/api/leave/repository/LeaveRepository.java
@@ -18,8 +18,7 @@ import java.util.Optional;
 public interface LeaveRepository extends BaseJpaRepository<Leave, Long>, JpaSpecificationExecutor<Leave> {
 
     @EntityGraph(attributePaths = {"user", "user.team", "user.avatar", "type", "activatedType"}, type = EntityGraph.EntityGraphType.FETCH)
-    Optional<Leave> findByUserIdAndId(Long userId, Long id);
-
+    Optional<Leave> findByOrganizationIdAndId(Long organizationId, Long id);
 
     @EntityGraph(attributePaths = {"user", "user.team", "user.avatar", "type", "activatedType"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<Leave> findByOrganizationIdAndUserId(Long organizationId, Long userId, Pageable page);

--- a/src/main/java/app/teamwize/api/leave/rest/controller/LeaveController.java
+++ b/src/main/java/app/teamwize/api/leave/rest/controller/LeaveController.java
@@ -94,7 +94,7 @@ public class LeaveController {
 
     @GetMapping("{id}")
     public LeaveResponse getDayOff(@PathVariable Long id) throws LeaveNotFoundException {
-        return leaveMapper.toLeaveResponse(leaveService.getLeave(securityService.getUserId(), id));
+        return leaveMapper.toLeaveResponse(leaveService.getLeave(securityService.getUserOrganizationId(), id));
     }
 
     @PostMapping("check")

--- a/src/main/java/app/teamwize/api/leave/service/LeaveService.java
+++ b/src/main/java/app/teamwize/api/leave/service/LeaveService.java
@@ -25,6 +25,7 @@ import app.teamwize.api.leave.rest.model.request.LeaveFilterRequest;
 import app.teamwize.api.organization.domain.entity.Organization;
 import app.teamwize.api.organization.exception.OrganizationNotFoundException;
 import app.teamwize.api.organization.service.OrganizationService;
+import app.teamwize.api.user.domain.UserRole;
 import app.teamwize.api.user.domain.entity.User;
 import app.teamwize.api.user.exception.UserNotFoundException;
 import app.teamwize.api.user.service.UserService;
@@ -117,19 +118,25 @@ public class LeaveService {
 
 
     @Transactional
-    public Leave updateLeave(Long organizationId, Long userId, Long id, LeaveUpdateCommand request) throws LeaveNotFoundException, LeaveUpdateStatusFailedException, UserNotFoundException {
-        var user = userService.getUser(organizationId, userId);
-        var leave = getById(userId, id);
+    public Leave updateLeave(Long organizationId, Long approverId, Long id, LeaveUpdateCommand request) throws LeaveNotFoundException, LeaveUpdateStatusFailedException, UserNotFoundException {
+        var approverUser = userService.getUser(organizationId, approverId);
+        if (approverUser.getRole() != UserRole.ORGANIZATION_ADMIN && approverUser.getRole() != UserRole.TEAM_ADMIN) {
+            throw new LeaveUpdateStatusFailedException("Leave update failed because user is not authorized to update leave, id = " + id);
+        }
+        var leave = leaveRepository.findByOrganizationIdAndId(organizationId, id).orElseThrow(() -> new LeaveNotFoundException("Leave not found with id: " + id));
+        if (approverUser.getRole() == UserRole.TEAM_ADMIN && !leave.getUser().getTeam().getId().equals(approverUser.getTeam().getId())) {
+            throw new LeaveUpdateStatusFailedException("Leave update failed because user is not authorized to update leave, id = " + id);
+        }
         if (leave.getStatus() != LeaveStatus.PENDING) {
             throw new LeaveUpdateStatusFailedException("Leave update failed because it is not in pending status, id = " + id);
         }
         leave.setStatus(request.status());
-        eventService.emmit(organizationId, new LeaveStatusUpdatedEvent(new LeaveEventPayload(leave), new UserEventPayload(user)));
+        eventService.emmit(organizationId, new LeaveStatusUpdatedEvent(new LeaveEventPayload(leave), new UserEventPayload(approverUser)));
         return leaveRepository.update(leave);
     }
 
-    public Leave getLeave(Long userId, Long id) throws LeaveNotFoundException {
-        return getById(userId, id);
+    public Leave getLeave(Long organizationId, Long id) throws LeaveNotFoundException {
+        return getById(organizationId, id);
     }
 
     public Float getTotalDuration(Long organizationId, Long userId, LeavePolicyActivatedTypeId activatedTypeId, LeaveStatus status) {
@@ -137,14 +144,14 @@ public class LeaveService {
         return sum != null ? sum : 0f;
     }
 
-    private Leave getById(Long userId, Long id) throws LeaveNotFoundException {
-        return leaveRepository.findByUserIdAndId(userId, id).orElseThrow(() -> new LeaveNotFoundException("Leave not found with id: " + id));
+    private Leave getById(Long OrganizationId, Long id) throws LeaveNotFoundException {
+        return leaveRepository.findByOrganizationIdAndId(OrganizationId, id).orElseThrow(() -> new LeaveNotFoundException("Leave not found with id: " + id));
     }
 
     public List<UserLeaveBalance> getLeaveBalance(Long organizationId, Long userId) throws UserNotFoundException, LeavePolicyNotFoundException {
         var user = userService.getUser(organizationId, userId);
         var policy = leavePolicyService.getLeavePolicy(organizationId, user.getLeavePolicy().getId());
-        var startedAt = user.getCreatedAt();
+        var startedAt = user.getJoinedAt();
         var result = new ArrayList<UserLeaveBalance>();
         for (var activatedType : policy.getActivatedTypes()) {
             var usedAmount = this.getTotalDuration(organizationId, userId, activatedType.getId(), LeaveStatus.ACCEPTED);
@@ -153,9 +160,9 @@ public class LeaveService {
                 case PER_MONTH ->
                         Period.between(startedAt.atZone(user.getTimeZoneId()).toLocalDate(), LocalDate.now()).toTotalMonths() * activatedType.getAmount();
                 case PER_YEAR ->
-                        (Period.between(startedAt.atZone(user.getTimeZoneId()).toLocalDate(), LocalDate.now()).toTotalMonths() / 12) * activatedType.getAmount();
+                        (Period.between(startedAt.atZone(user.getTimeZoneId()).toLocalDate(), LocalDate.now()).toTotalMonths() / 12f) * activatedType.getAmount();
             };
-            result.add(new UserLeaveBalance(activatedType, usedAmount.longValue(), totalAmount, startedAt.atZone(user.getTimeZoneId()).toLocalDate()));
+            result.add(new UserLeaveBalance(activatedType, usedAmount.longValue(), (long) totalAmount, startedAt.atZone(user.getTimeZoneId()).toLocalDate()));
         }
         return result;
     }
@@ -207,5 +214,3 @@ public class LeaveService {
     }
 
 }
-// Range 17 April to 25 April
-// we want to know the leave request that started between 17 to 25 April or ended between 17 to 25 April

--- a/src/main/java/app/teamwize/api/user/domain/entity/User.java
+++ b/src/main/java/app/teamwize/api/user/domain/entity/User.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Objects;
 
@@ -43,7 +44,7 @@ public class User extends BaseAuditEntity {
     private UserStatus status;
     @ManyToOne(fetch = FetchType.LAZY)
     private Asset avatar;
-
+    private Instant joinedAt;
     @ManyToOne
     private LeavePolicy leavePolicy;
 

--- a/src/main/java/app/teamwize/api/user/domain/request/UserCreateRequest.java
+++ b/src/main/java/app/teamwize/api/user/domain/request/UserCreateRequest.java
@@ -2,6 +2,8 @@ package app.teamwize.api.user.domain.request;
 
 import app.teamwize.api.user.domain.UserRole;
 
+import java.time.Instant;
+
 public record UserCreateRequest(
         String email,
         String firstName,
@@ -12,5 +14,6 @@ public record UserCreateRequest(
         String timezone,
         String country,
         Long teamId,
-        Long leavePolicyId) {
+        Long leavePolicyId,
+        Instant joinedAt) {
 }

--- a/src/main/java/app/teamwize/api/user/domain/request/UserUpdateRequest.java
+++ b/src/main/java/app/teamwize/api/user/domain/request/UserUpdateRequest.java
@@ -3,9 +3,12 @@ package app.teamwize.api.user.domain.request;
 
 import app.teamwize.api.base.validator.PhoneNumber;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 import org.openapitools.jackson.nullable.JsonNullable;
+
+import java.time.Instant;
 
 @Data
 public class UserUpdateRequest {
@@ -27,4 +30,7 @@ public class UserUpdateRequest {
     private JsonNullable<Long> leavePolicyId;
 
     private JsonNullable<Long> teamId;
+
+    @NotNull
+    private JsonNullable<Instant> joinedAt;
 }

--- a/src/main/java/app/teamwize/api/user/domain/response/UserResponse.java
+++ b/src/main/java/app/teamwize/api/user/domain/response/UserResponse.java
@@ -3,13 +3,14 @@ package app.teamwize.api.user.domain.response;
 
 import app.teamwize.api.assets.domain.model.response.AssetCompactResponse;
 import app.teamwize.api.leave.rest.model.response.LeavePolicyCompactResponse;
+import app.teamwize.api.organization.domain.response.OrganizationCompactResponse;
 import app.teamwize.api.team.domain.response.TeamCompactResponse;
 import app.teamwize.api.user.domain.UserRole;
 import app.teamwize.api.user.domain.UserStatus;
-import app.teamwize.api.organization.domain.response.OrganizationCompactResponse;
-
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
+
+import java.time.Instant;
 
 
 public record UserResponse(
@@ -25,6 +26,9 @@ public record UserResponse(
         @Nonnull OrganizationCompactResponse organization,
         @Nonnull TeamCompactResponse team,
         @Nonnull AssetCompactResponse avatar,
-        @Nonnull LeavePolicyCompactResponse leavePolicy
+        @Nonnull LeavePolicyCompactResponse leavePolicy,
+        @Nonnull Instant joinedAt,
+        @Nonnull Instant createdAt,
+        @Nonnull Instant updatedAt
 ) {
 }

--- a/src/main/java/app/teamwize/api/user/service/UserService.java
+++ b/src/main/java/app/teamwize/api/user/service/UserService.java
@@ -33,6 +33,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+
 import static app.teamwize.api.user.repository.UserSpecifications.*;
 
 @Slf4j
@@ -87,7 +89,8 @@ public class UserService {
                 .setCountry(request.country())
                 .setTeam(team)
                 .setOrganization(organization)
-                .setLeavePolicy(leavePolicy);
+                .setLeavePolicy(leavePolicy)
+                .setJoinedAt(Instant.now());
         user.setTeam(team);
         user.setPassword(passwordEncoder.encode(request.password()));
         return userRepository.merge(user);
@@ -116,7 +119,8 @@ public class UserService {
                 .setCountry(request.country())
                 .setTeam(team)
                 .setOrganization(organization)
-                .setLeavePolicy(leavePolicy);
+                .setLeavePolicy(leavePolicy)
+                .setJoinedAt(request.joinedAt() == null ? Instant.now() : request.joinedAt());
 
         if (request.password() != null && !request.password().isBlank()) {
             user.setPassword(passwordEncoder.encode(request.password()));
@@ -143,6 +147,10 @@ public class UserService {
         }
         if (request.getPhone() != null) {
             request.getPhone().ifPresent(user::setPhone);
+        }
+
+        if (request.getJoinedAt() != null) {
+            request.getJoinedAt().ifPresent(user::setJoinedAt);
         }
 
         if (request.getAvatarAssetId() != null && request.getAvatarAssetId().isPresent()) {

--- a/src/main/resources/db/changelog/20250305-2010-add-joined-at-to-users-table.xml
+++ b/src/main/resources/db/changelog/20250305-2010-add-joined-at-to-users-table.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd">
+
+    <changeSet id="20250305-2010-add-joined-at-to-users-table" author="M.Karimi">
+        <addColumn tableName="users">
+            <column name="joined_at" type="TIMESTAMP WITHOUT TIME ZONE" defaultValueDate="NOW()">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
# Allow org and team admin to allow all leaves

## Description

Org and Team admins should be able to accept/reject all user's leaves.

## Changes

- Summarize key changes made in this pull request.

## Checklist

- [x] Code adheres to the project’s back-end guidelines.
- [x] Unit tests cover new functionality.
- [x] Integration tests are added or updated.
- [x] Exception handling is implemented consistently.
- [x] Logging is added for critical operations.
- [x] Database migrations (if applicable) are included and tested.
- [x] API documentation is updated if necessary.
- [x] Changes are reviewed for potential performance impacts.
- [x] Security vulnerabilities are assessed and mitigated.
- [x] Dependencies are updated or verified as compatible.
- [x] Code is reviewed for readability and maintainability.
- [x] Environment configurations (if any) are documented.
- [x] Endpoints are tested for expected behavior.

